### PR TITLE
Add link to Guide for Beginniers

### DIFF
--- a/index.php
+++ b/index.php
@@ -27,6 +27,10 @@
         <div style="margin: 0; padding: 0;">
             <h2 style="height: 10px">Paradise</h2>
         </div>
+        <div style="font-size: 150%">
+            <p>New to Paradise Station or Space Station 13? <br>
+            <a href="http://nanotrasen.se/wiki/index.php/Guide_for_beginners">Read the Guide for Beginners!</a></p>
+        </div>
         <div>
             <a href="http://nanotrasen.se/phpBB3">Paradise Forums</a>
         </div>


### PR DESCRIPTION
Added a visible link to the Guide for Beginners page of the wiki.

It might not be obvious to a new visitor to the site where to go or what to do at first, so a direct link to the guide will not only familiarize them with SS13 and Paradise, but it will also get them onto the wiki in the first place.

This helps for users who may not initially deem it necessary to start by reading the wiki.