### PR TITLE
Fix real-world mobile device view

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Paradise Station</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="reset.css">
     <link rel="stylesheet" type="text/css" href="stylesheet.css">
     <link href="https://fonts.googleapis.com/css?family=Exo" rel="stylesheet">


### PR DESCRIPTION
This meta tag is required for mobile devices to present the correct max-width view, instead of presenting their real screen resolution.

Any newer devices would always have a max-width about 600px, thus making the mobile CSS not trigger in real-world conditions.